### PR TITLE
DEVOPS-8491: Pin all GitHub Actions to SHA256 hashes

### DIFF
--- a/.github/workflows/idd-example.yml
+++ b/.github/workflows/idd-example.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: create container
         run: docker build . --file Dockerfile -t whs:bwapp


### PR DESCRIPTION
Pin external GitHub Actions to SHA256 hashes for supply chain security.

**References:**
- DEVOPS-8490: GitHub Actions SHA pinning initiative
- DEVOPS-8491: Shai Hulud worm remediation

**Changes:**
- Only external actions (actions/*, docker/*, etc.) are modified
- Internal pipelines-library references remain unchanged
- Version comments added for readability (e.g., # v4)